### PR TITLE
Feature: Open external links in new tabs

### DIFF
--- a/app/_components/EggspressImage.tsx
+++ b/app/_components/EggspressImage.tsx
@@ -1,8 +1,16 @@
 import Image from 'next/image'
 import React from 'react'
 
+interface EggspressImageProps {
+  src: string,
+  alt: string,
+  width: number,
+  height: number,
+  className: string,
+  fetchPriority?: "high" | "low" | "auto" | undefined
+}
 
-const EggspressImage: React.FC<{src: string, alt: string, width: number, height: number, className: string, fetchPriority?: "high" | "low" | "auto" | undefined}> = ({src, alt, width, height, className, fetchPriority}: {src: string, alt: string, width: number, height: number, className: string, fetchPriority?: "high" | "low" | "auto" | undefined}) => {
+const EggspressImage: React.FC<EggspressImageProps> = ({src, alt, width, height, className, fetchPriority}: EggspressImageProps) => {
   const videoExtensions = ['.webm', '.mp4', '.m4v', '.mov', '.wmv', '.asf', '.avi', '.mpg', '.mpeg']
   const srcExtension = src.slice(src.lastIndexOf('.'))
 

--- a/app/_components/EggspressLink.tsx
+++ b/app/_components/EggspressLink.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import React from 'react'
+
+interface EggspressLinkProps {
+  href: string;
+  children: React.ReactNode
+}
+
+// isUrlAbsolute comes from https://stackoverflow.com/a/38979205
+const isUrlAbsolute = (url:string): boolean => (url.indexOf('//') === 0 ? true : url.indexOf('://') === -1 ? false : url.indexOf('.') === -1 ? false : url.indexOf('/') === -1 ? false : url.indexOf(':') > url.indexOf('/') ? false : url.indexOf('://') < url.indexOf('.') ? true : false)
+
+
+const EggspressLink: React.FC<EggspressLinkProps> = ({href, children}: EggspressLinkProps) => {
+  return (
+    isUrlAbsolute(href) ? <Link href={href} target="_blank">{children}</Link> : <Link href={href}>{children}</Link>
+  )
+}
+
+export default EggspressLink

--- a/app/_components/compileContent.ts
+++ b/app/_components/compileContent.ts
@@ -1,6 +1,7 @@
 import { compileMDX } from 'next-mdx-remote/rsc'
 import getContent from '../_components/getContent'
 import EggspressImage from '../_components/EggspressImage'
+import EggspressLink from '../_components/EggspressLink'
 import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
 import eggspressMedia from '@/plugins/eggspress-img-processor'
@@ -24,7 +25,8 @@ const compileContent = async (type: string, slug:string,): Promise<{content: Rea
       }
     },
     components: {
-      img: EggspressImage as any
+      img: EggspressImage as any,
+      a: EggspressLink as any
     }
   })
 


### PR DESCRIPTION
The purpose of this PR is to improve the reader experience when readers follow links from content (posts, pages, etc.). Prior to this PR, all links caused the browser to navigate away from the current Eggspress content. This behavior is now modified to keep users on the Eggspress site where it makes sense to do so.

While the ideal solution is to determine the current domain using something like `window.location` or `location`, we are unable to access either during server side rendering. As a result, we opt for the next best option, which is to check whether a URL is absolute or relative. This is not perfect, but is sufficient for a quick implementation.

To implement, we modify `compileContent` component to map anchor `<a>` tags to `EggspressLink` custom element. `EggspressLink` takes an anchor tag and evaluates its `href` value. If `href` seems to be an absolute link, we return a `<Link>` element (from `next/link`) that sets `target="_blank"`, which causes a new tab to open. Otherwise, if `href` is a relative link, we assume that it is an internal link and we do not set `target="_blank"`.