### PR TITLE
Feature: OrderBy and Previous/Next Post

### DIFF
--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -17,9 +17,10 @@ export async function generateMetadata() {
 }
 
 export default async function Home() {
-  const postFrontmatter = await getFrontmatter('posts')
   const blogSettings = await getEggspressSettings('metadata')
   const appearanceSettings = await getEggspressSettings('appearance')
+  console.log(appearanceSettings.orderPostsBy, appearanceSettings.orderPostsByReversed)
+  const postFrontmatter = await getFrontmatter('posts', appearanceSettings.orderPostsBy, appearanceSettings.orderPostsByReversed)
 
   if (blogSettings && blogSettings.code && blogSettings.code === 'ENOENT') {
     return (

--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -48,22 +48,24 @@ export async function generateMetadata({ params }: { params: {category: string}}
 
 const CategoryPage = async ({ params }: { params: { category: string }}) => {
   const { category } = params
-  const postFrontmatter = await getFrontmatter('posts')
-  const filteredPosts = postFrontmatter.filter(post => createSlug(post.category) === category)
-  const numbersAsWords: Record<number, string> = {0: 'No', 1: 'One', 2: 'Two', 3: 'Three', 4: 'Four', 5: 'Five', 6: 'Six', 7: 'Seven', 8: 'Eight', 9: 'Nine'}
   const appearanceSettings = await getEggspressSettings('appearance')
 
-
+  const numbersAsWords: Record<number, string> = {0: 'No', 1: 'One', 2: 'Two', 3: 'Three', 4: 'Four', 5: 'Five', 6: 'Six', 7: 'Seven', 8: 'Eight', 9: 'Nine'}
+  
+  
   const categoryFrontmatter = await getFrontmatter('categories')
   const categoryData = categoryFrontmatter.filter(fm => fm.slug === category)[0]
+
+  const postFrontmatter = await getFrontmatter('posts', categoryData.orderPostsBy, categoryData.orderPostsByReversed)
+  const filteredPosts = postFrontmatter.filter(post => createSlug(post.category) === category)
   
   let categoryName = filteredPosts && filteredPosts.length ? filteredPosts[0].category : decodeURI(category)
   if (categoryData) {
     categoryName = categoryData.title
   }
-
+  
   categoryName = categoryName || category
-
+  
   return (
     <div className="flex flex-wrap">
       <div className={`hero bleed-${appearanceSettings.colorLightPrimary} dark:bleed-${appearanceSettings.colorDarkPrimary}`}>

--- a/app/[category]/page/[page]/page.tsx
+++ b/app/[category]/page/[page]/page.tsx
@@ -48,25 +48,27 @@ export async function generateMetadata({ params }: { params: { category: string,
   categoryName = categoryName || category
     
   return {
-    title: `Page ${page} - ${categoryName}`
+    title: `Page ${pageNumber} - ${categoryName}`
   }
 }
 
 export default async function BlogPage({ params }: { params: { category: string, page: string } }) {
   const { category, page } = params
   const pageNumber = parseInt(page)
-  const postFrontmatter = await getFrontmatter('posts')
   const appearanceSettings = await getEggspressSettings('appearance')
+
   const numPostsPerPage = appearanceSettings.numberOfPostsPerPage || 8
   
-  const filteredPosts = postFrontmatter.filter(post => createSlug(post.category) === category)
-
-  const endIndex = pageNumber * numPostsPerPage > filteredPosts.length ? filteredPosts.length : pageNumber * numPostsPerPage
-  const startIndex = pageNumber * numPostsPerPage - numPostsPerPage > filteredPosts.length ? endIndex - numPostsPerPage : pageNumber * numPostsPerPage - numPostsPerPage
-
+  
   const categoryFrontmatter = await getFrontmatter('categories')
   const categoryData = categoryFrontmatter.filter(fm => fm.slug === category)[0]
-
+  
+  const postFrontmatter = await getFrontmatter('posts', categoryData.orderPostsBy, categoryData.orderPostsByReversed)
+  const filteredPosts = postFrontmatter.filter(post => createSlug(post.category) === category)
+  
+  const endIndex = pageNumber * numPostsPerPage > filteredPosts.length ? filteredPosts.length : pageNumber * numPostsPerPage
+  const startIndex = pageNumber * numPostsPerPage - numPostsPerPage > filteredPosts.length ? endIndex - numPostsPerPage : pageNumber * numPostsPerPage - numPostsPerPage
+  
   let categoryName = filteredPosts && filteredPosts.length ? filteredPosts[0].category : decodeURI(category)
   if (categoryData) {
     categoryName = categoryData.title

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -8,19 +8,13 @@ import getFrontmatter from './getFrontmatter'
 import AuthorLinks from '../_components/AuthorLinks'
 
 const Footer = async () => {
-  const postFrontmatter = await getFrontmatter('posts')
-  const categoryNames = new Set(postFrontmatter.filter(
-    (post) => { if (!post.category) {return false} return true }
-  ).map((post) => post.category))
-  const arrayOfCategoryNames = Array.from(categoryNames)
-  const categoryData = arrayOfCategoryNames.map((name) => {return {name: name, slug: createSlug(name)}})
-  const pageFrontmatter = await getFrontmatter('pages')
-  const pages = pageFrontmatter.map((page) => {return {name: page.title, tagline: page.tagline, priority: page.weight, slug: page.slug}})
-  const pageData = pages.sort((a, b) => {
-    return (a.priority || 0) < (b.priority || 0) ? -1 : 1
-  })
-  const blogSettings = await getEggspressSettings('metadata')
   const appearanceSettings = await getEggspressSettings('appearance')
+
+  const categoryFrontmatter = await getFrontmatter('categories', appearanceSettings.orderCategoriesBy, appearanceSettings.orderCategoriesByReversed)
+  const categoryData = categoryFrontmatter.map((category) => {return {title: category.title, slug: createSlug(category.slug)}})
+
+  const pageFrontmatter = await getFrontmatter('pages', appearanceSettings.orderPagesBy, appearanceSettings.orderPagesByReversed)
+  const pageData = pageFrontmatter.map((page) => {return {name: page.title, tagline: page.tagline, priority: page.weight, slug: page.slug}})
 
   return (
     <div className={`px-3 md:px-0 py-8 min-w-full duration-100 bg-${appearanceSettings.colorLightFooter || appearanceSettings.colorLightPrimary} dark:bg-${appearanceSettings.colorDarkFooter || appearanceSettings.colorDarkPrimary} pt-12`}>
@@ -29,7 +23,7 @@ const Footer = async () => {
           <div className="w-1/2">
             <div className="flex flex-col w-full sm:w-1/2 mb-3">
               {categoryData.map(category => 
-                <Link className="mb-6 md:mb-3" key={category.slug} href={`/${category.slug}`}>{category.name}</Link>
+                <Link className="mb-6 md:mb-3" key={category.slug} href={`/${category.slug}`}>{category.title}</Link>
               )}
             </div>
             <div className="flex flex-col w-full sm:w-1/2 mb-3">

--- a/app/_components/getFrontmatter.ts
+++ b/app/_components/getFrontmatter.ts
@@ -19,7 +19,7 @@ const extractFrontmatter = async (markdownData: {content: string, slug: string, 
   return frontmatterData
 }
 
-const getFrontmatter = async <T extends string>(type: T): Promise<ItemType<T>[]> => {
+const getFrontmatter = async <T extends string>(type: T, sortBy?: string, sortReversed?: boolean): Promise<ItemType<T>[]> => {
   const dir = `./my_${type}/`
   const allowedExtensions = ['.md', '.mdx']
   const files = await getFilesRecursivelyWithExtensions(dir, allowedExtensions)
@@ -35,7 +35,15 @@ const getFrontmatter = async <T extends string>(type: T): Promise<ItemType<T>[]>
 
   const frontmatterData = await extractFrontmatter(data)
   const sortedData = frontmatterData.sort((a, b) => {
-    const x = (a.date || a.publishDate || 0) < (b.date || b.publishDate || 0) ? 1 : -1
+    let x = (a.date || a.publishDate || 0) < (b.date || b.publishDate || 0) ? 1 : -1
+    if (sortBy === 'weight') {
+      x = a.weight < b.weight ? -1 : 1
+    } else if (sortBy?.startsWith('alpha')) {
+      x = (a.title || a.name || 0) < (b.title || b.name || 0) ? -1 : 1
+    }
+    if (sortReversed) {
+      return -x
+    }
     return x
   })
   

--- a/app/author/[slug]/page.tsx
+++ b/app/author/[slug]/page.tsx
@@ -55,7 +55,8 @@ const getProfileImage =  async (imageFileName: string): Promise<string | null> =
 const AuthorPage =  async ( {params}: {params: {slug: string}} ) => {
   const { slug } = params
   const { content, frontmatter, contentLength } = await compileContent('authors', slug)
-  const postFrontmatter = await getFrontmatter('posts')
+
+  const postFrontmatter = await getFrontmatter('posts', frontmatter.orderPostsBy, frontmatter.orderPostsByReversed)
   const authorPosts = postFrontmatter.filter(fm => fm.author === slug || fm.author?.split(',').map(x => x.trim()).includes(slug))
 
   const imageUrl = frontmatter && frontmatter.image ? await getProfileImage(frontmatter.image) : ''
@@ -94,9 +95,9 @@ const AuthorPage =  async ( {params}: {params: {slug: string}} ) => {
         <div className="max-w-prose">
           {authorPosts &&
             <div className="max-w-prose border-b">
-              <h2 className="text-gray-600 font-semibold mb-3">Latest posts</h2>
-              {authorPosts.map(fm =>
-                <PostCard key={fm.slug} post={fm}></PostCard>
+              <h2 className="text-gray-600 text-sm font-semibold mb-6">Posts by {frontmatter.name}</h2>
+              {authorPosts.map((fm, index) =>
+                <PostCard key={`${fm.slug}-${index}`} post={fm}></PostCard>
               )}
             </div>
           }
@@ -112,9 +113,9 @@ const AuthorPage =  async ( {params}: {params: {slug: string}} ) => {
         </div>
 
         <Sidebar>
-          {sections.map(section => {return (frontmatter[section] &&
+          {sections.map((section, index) => {return (frontmatter[section] &&
             <div>
-              <div key={`social-index`} className="text-sm text-gray-500 w-full mb-3">
+              <div key={`${section}-${index}`} className="text-sm text-gray-500 w-full mb-3">
                 <h4 className="font-semibold mb-0.5">{section ? section.charAt(0).toUpperCase() + section.slice(1) : ''}</h4>
                 <div className="text-gray-700 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300">
                   {frontmatter[section]}
@@ -124,7 +125,7 @@ const AuthorPage =  async ( {params}: {params: {slug: string}} ) => {
           )})}
 
           {[1, 2].map(index => {return (frontmatter['socialLink' + index] &&
-            <div key={`social-index`} className="text-sm text-gray-500 w-full mb-3">
+            <div key={`${frontmatter['socialLink' + index]}-${index}`} className="text-sm text-gray-500 w-full mb-3">
               <div>
                 <h4 className="font-semibold mb-0.5">{frontmatter['socialPlatform' + index] ? `${frontmatter['socialPlatform' + index]}` : 'Social'}</h4>
                 <a href={frontmatter['socialLink' + index]} target="_blank" rel="nofollow noopener" className="text-gray-700 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 underline-animated">
@@ -137,7 +138,7 @@ const AuthorPage =  async ( {params}: {params: {slug: string}} ) => {
           
           {frontmatter.websiteLink && (
             <div>
-              <div key={`social-index`} className="text-sm text-gray-500 w-full mb-3">
+              <div className="text-sm text-gray-500 w-full mb-3">
                 <h4 className="font-semibold mb-0.5">Website</h4>
                 <a href={frontmatter.websiteLink} target="_blank" rel="nofollow noopener" className="text-gray-700 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 underline-animated">
                   {frontmatter.websiteLink && frontmatter.websiteName ? frontmatter.websiteName : frontmatter.websiteLink.slice(frontmatter.websiteLink.lastIndexOf('://')+3)}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -51,6 +51,11 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
   const appearanceSettings = await getEggspressSettings('appearance')
   const authors = frontmatter && frontmatter.author ? frontmatter.author.split(',').map((author: string) => author.trim().replaceAll('_', '-').replaceAll(' ', '-')) : []
 
+  const postFrontmatter = await getFrontmatter('posts')
+  const prevPost = postFrontmatter.filter(post => post.slug === frontmatter.prevPost.replaceAll('_', '-').replaceAll(' ', '-'))[0]
+  const nextPost = postFrontmatter.filter(post => post.slug === frontmatter.nextPost.replaceAll('_', '-').replaceAll(' ', '-'))[0]
+
+
   return (
     <div className="flex flex-wrap">
       <div className={`hero bleed-${appearanceSettings.colorLightPrimary} dark:bleed-${appearanceSettings.colorDarkPrimary}`}>
@@ -66,9 +71,26 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
           <div className="prose dark:prose-invert">
             {content}
           </div>
-          {
-            authors.length &&
-            <div className="flex lg:hidden px-1 border-t mt-12 -mb-16 pt-12">
+
+          {(nextPost || prevPost) &&
+              <div className="flex flex-wrap border-t mt-12 py-6 text-gray-800 dark:text-gray-200">
+                {prevPost &&
+                <Link className="grow" href={`/blog/${prevPost.slug}`}>
+                    <div className="text-sm font-light mb-2">Previous Post</div>
+                    <div className="font-semibold">{prevPost.title}</div>
+                </Link>
+                }
+                {nextPost &&
+                <Link className="grow" href={`/blog/${nextPost.slug}`}>
+                    <div className="text-sm font-light mb-2">Next Post</div>
+                    <div className="font-semibold">{nextPost.title}</div>
+                </Link>
+                }
+              </div>
+          }
+
+          {authors.length &&
+            <div className={`${(nextPost || prevPost) ? '' : 'mt-12' }flex lg:hidden px-1 border-t -mb-16 pt-12`}>
               <div className="md:w-5/6">
                 {authors.map((author: string) => 
                   <AuthorCard key={`author-body-${author}`} slug={author}></AuthorCard>
@@ -79,14 +101,13 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
 
           {(frontmatter.relatedPost1 || frontmatter.relatedPost2 || frontmatter.relatedPost3 || frontmatter.relatedPost4)
             ?
-            <div className="flex border-t mt-12 pt-12 max-w-prose">
+            <div className={`${(nextPost || prevPost || authors.length) ? '' : 'mt-12'}flex border-t pt-12 max-w-prose`}>
               <div className="mb-8">
                 <div className="flex flex-wrap mb-3">
                   <Image src={Relation} alt="relation icon" className="h-7 w-7 dark:border-gray-600 stroke-gray-200 fill-gray-200 brightness-50 dark:brightness-100"></Image>
                   <div className="font-medium text-gray-700 dark:text-gray-300 my-auto pl-2">Related Posts</div>
                 </div>
                 {[1, 2, 3, 4].map(async (index: number) => {
-                  const postFrontmatter = await getFrontmatter('posts')
                   const postData = postFrontmatter.filter(fm => frontmatter['relatedPost' + index] && fm.slug === frontmatter['relatedPost' + index].replaceAll('_', '-').replaceAll(' ', '-'))
         
                   if (postData.length) {
@@ -122,7 +143,6 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
                   <div className="font-medium text-sm text-gray-600 dark:text-gray-300 my-auto pl-1">Related Posts</div>
                 </div>
                 {[1, 2, 3, 4].map(async (index: number) => {
-                  const postFrontmatter = await getFrontmatter('posts')
                   const postData = postFrontmatter.filter(fm => frontmatter['relatedPost' + index] && fm.slug === frontmatter['relatedPost' + index].replaceAll('_', '-').replaceAll(' ', '-'))
         
                   if (postData.length) {

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -29,8 +29,9 @@ export async function generateMetadata({ params }: { params: { page: string } })
 export default async function BlogPage({ params }: { params: { page: string } }) {
   const { page } = params
   const pageNumber = parseInt(page)
-  const postFrontmatter = await getFrontmatter('posts')
   const appearanceSettings = await getEggspressSettings('appearance')
+  
+  const postFrontmatter = await getFrontmatter('posts', appearanceSettings.orderPostsBy, appearanceSettings.orderPostsByReversed)
   const numPostsPerPage = appearanceSettings.numberOfPostsPerPage || 8
 
   const endIndex = pageNumber * numPostsPerPage > postFrontmatter.length ? postFrontmatter.length : pageNumber * numPostsPerPage


### PR DESCRIPTION
To provide authors and admins with more control over how their posts appear, we add:
- the ability to order how content appears
- previous and next post links at the end of posts

To achieve ordering, we add `order<content-type>By` and `order<content-type>ByReversed`. Content may be ordered by the following values for the `orderBy` keys: `alphabetical`, `date`, and `weight`. This may be combined with a reverse sort.

Further, each category and each author may define how their posts are sorted through `orderPostsBy` and `orderPostsByReversed`. This may be useful for categories in which sequence is important, for example, in a tutorial series. Authors may also wish to display their posts by the relative importance they assign them (through the `weight` key).

By default, sorting is done by `date` with `order<content-type>ByReversed` set to `false`.

Previous and next post links can now be found at the end of posts. To define a previous or next post, authors should set the `prevPost` and `nextPost` frontmatter fields with the slug identifiers of other posts.