### PR TITLE
Bugfix: Layout and Default UI Behaviors

### DIFF
--- a/app/_components/Navigation.tsx
+++ b/app/_components/Navigation.tsx
@@ -15,7 +15,7 @@ const Navigation = async () => {
       <div className="flex container justify-between">
         <div className="flex">
           <Link className="flex items-center" href='/'>
-            {appearanceSettings.showBrandLogo && 
+            {(appearanceSettings.showBrandLogo === undefined || appearanceSettings.showBrandLogo) && 
               <Image src="/assets/logo.png" height={32} width={32} style={{width: 'auto', height: 'auto'}} alt='Eggspress blog logo' className='dark:hue-rotate-270 dark:brightness-[3] mr-2' />
             }
             {appearanceSettings.showBrandText &&

--- a/app/_components/Navigation.tsx
+++ b/app/_components/Navigation.tsx
@@ -24,7 +24,6 @@ const Navigation = async () => {
           </Link>
         </div>
         <div className="flex items-center dark:text-white">
-            {/* <div className="mr-1">Contact</div> */}
             <DarkModeToggle />
             <DropdownMenu>
               <NavigationMenu>
@@ -33,8 +32,6 @@ const Navigation = async () => {
                 </div>
               </NavigationMenu>
             </DropdownMenu>
-            {/* <div className="mr-1">Website</div>
-            <div className="mr-1">Blah</div> */}
         </div>
       </div>
     </nav>

--- a/app/_components/PostCard.tsx
+++ b/app/_components/PostCard.tsx
@@ -104,10 +104,10 @@ const PostCard = async ({ post, index, priority=true }: PostProps) => {
           <div className={`text-sm font-medium ${(appearanceSettings.showPostCardAuthor && authorData) && appearanceSettings.showPostCardCategory && post.category ? 'w-full sm:w-auto mt-2 sm:mt-0' : ''}`}>{convertDate(post.date || post.publishDate)}</div>
         }
       </div>
-      {appearanceSettings.showPostCardSnippet &&
+      {(appearanceSettings.showPostCardSnippet === undefined || appearanceSettings.showPostCardSnippet) &&
         <div className='w-full mb-3 leading-7 line-clamp-4'>{post.snippet || post.description}</div>
       }
-      {appearanceSettings.showPostCardReadMoreButton && post.slug &&
+      {(appearanceSettings.showPostCardReadMoreButton === undefined || appearanceSettings.showPostCardReadMoreButton) && post.slug &&
         <div className={`${await getColors('text', 'PostCardReadMoreText', 'white', 'gray-800')}`}>
           <ReadMore slug={post.slug}></ReadMore>
         </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -71,6 +71,7 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
   const categoryData = categoryFrontmatter.filter(fm => fm.slug === frontmatter.category)[0]
   const categoryName = categoryData && categoryData.title ? categoryData.title : frontmatter.category 
 
+
   return (
     <div className="flex flex-wrap">
       <ContentHero 
@@ -88,7 +89,7 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
       }
       <div className="flex justify-between w-full">
         <div className="overflow-x-hidden">
-          {appearanceSettings.showTableOfContentsOnMobile &&
+          {(appearanceSettings.showTableOfContentsOnMobile === undefined || appearanceSettings.showTableOfContentsOnMobile) &&
             <div className="mb-12 lg:hidden">
               <Toc />
             </div>
@@ -207,7 +208,7 @@ const PostPage =  async ( {params}: {params: {slug: string}} ) => {
             }
           </Sidebar>
           <PageSidebar isSticky={false} slug={frontmatter.sidebar}></PageSidebar>
-          {appearanceSettings.showTableOfContentsInSidebar &&
+          {(appearanceSettings.showTableOfContentsInSidebar === undefined || appearanceSettings.showTableOfContentsInSidebar) &&
             <Sidebar>
               <Toc />
             </Sidebar>

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,7 +56,7 @@ body {
   @apply leading-relaxed font-light my-2;
 }
 
-h2::before, h3::before, h4::before, h5::before { 
+ h2:not(#hero-subtitle)::before, h3::before, h4::before, h5::before { 
   display: block; 
   content: " "; 
   margin-top: -58px; 

--- a/app/scripts/loadAssets.js
+++ b/app/scripts/loadAssets.js
@@ -23,7 +23,14 @@ const setFontFamily = async (path) => {
         }
       }
     }
-  } catch (e) { console.warn(`Prebuild error encountered while adding custom font: ${e}`) } // skip setting custom font if settings are not available, typically during setup
+  } catch (e) { 
+    console.warn(`Prebuild error encountered while adding custom font. Applying default font "Roboto Flex."`)
+  
+    fs.writeFileSync(
+      'app/_components/UserFont.tsx',
+      `import { Roboto_Flex } from 'next/font/google'\nconst font = Roboto_Flex({ subsets: ['latin'], })\nexport default font`
+    )
+  } // should only run into this error during setup when file is not found, in which case we manually set a font
 
 }
 
@@ -132,7 +139,27 @@ const setSafelist = async (path) => {
           `.eggspress-content-extended {\n@apply ${contentClasses.join(' ')};\n}`)
       }
     }
-  } catch (e) { console.warn(`Prebuild error encountered while adding custom colors: ${e}`) } // skip setting custom font if settings are not available, typically during setup
+  } catch (e) {
+    console.warn(`Prebuild error encountered while adding custom colors. Applying minimal set of colors for Setup mode.`)
+
+    const safelist = [
+      'dark:bg-slate-900',
+      'dark:bg-slate-800',
+      'dark:bleed-slate-800',
+      'dark:bg-slate-800',
+      'dark:text-gray-200',
+      'dark:text-white',
+      'bg-gray-100',
+      'bg-white',
+      'bleed-white',
+      'text-gray-800',
+    ]
+
+    fs.writeFileSync(
+      'app/safelist.ts',
+      `const safelist = [${safelist.map(x => `'${x}'`)}]\nexport default safelist`
+    )
+  } // should only run into this error during setup when file is not found, in which case we set a minimum set of colors in safelist
 
 }
 


### PR DESCRIPTION
Fix bug introduced in https://github.com/dentonzh/Eggspress/pull/48 where in order to offset headings, we apply pseudo class `::before` to `h2`, `h3`, `h4`, and `h5`. This unintentionally affected our hero subtitle text, which is also in an `h2` tag. To resolve this issue, we add hero subtitle `id` to a `not` selector by modifying our `globals.css` to `h2:not(#hero-subtitle)::before`.

Default UI behaviors are also more clearly defined by using evaluating an OR condition where appropriate. For example, if `my_settings/appearance.md` is not available or certain keys are removed, such as `showBrandLogo`, then JSX will not render because these keys yield `undefined`. To resolve this, we render an element if the values for these keys are either `undefined` OR `true` (rather than just `true` as before).

Finally, this PR modifies `loadAssets.js` prebuild script to insert a fallback font and minimal Tailwind safelist. This is to ensure that in the absence of `my_settings/appearance.md` (such as during Setup) that certain elements still have the correct colors applied. Before this change, Setup did not load the correct colors, which meant that accent colors did not apply and dark mode did not work.
