### PR TITLE
Adding Prettier for code formatting conformity

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 120,
+  "arrowParens": "avoid",
+  "jsxSingleQuote": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^8",
         "eslint-config-next": "^14.0.4",
         "postcss": "^8",
+        "prettier": "3.2.5",
         "tailwindcss": "^3",
         "tailwindcss-full-bleed": "^2.0.1",
         "typescript": "^5"
@@ -6129,6 +6130,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^8",
     "eslint-config-next": "^14.0.4",
     "postcss": "^8",
+    "prettier": "3.2.5",
     "tailwindcss": "^3",
     "tailwindcss-full-bleed": "^2.0.1",
     "typescript": "^5"


### PR DESCRIPTION
I tried to make a `.prettierrc` configuration file that most closely resembles the formatting already used in this repository. Please test and verify that this configuration is adequate; note that files modified in future commits will be a direct result of this new formatting.