### PR TITLE
Bugfix: Build Configuration Files

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,8 +3,8 @@ frontend:
  phases:
     preBuild:
       commands:
+        - npm install
         - node ./app/scripts/prebuild.js
     build:
       commands:
-        - npm install
         - npm run build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  command = "node ./app/scripts/prebuild.js && npm install && npm run build"
+  command = "npm install && node ./app/scripts/prebuild.js && npm run build"

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "node ./app/scripts/prebuild.js && npm install"
+  "installCommand": "npm install && node ./app/scripts/prebuild.js"
 }  


### PR DESCRIPTION
**What is this?**
A fix to resolve https://github.com/dentonzh/Eggspress/issues/64.

**Implementation details**
Reversing the order in which the commands `npm install`, `node ./app/scripts/prebuild.js`, and `npm run build` are called seems to resolve this issue.