### PR TITLE
Bugfix: Mobile Table of Contents on Desktop

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -110,11 +110,13 @@ const PostPage = async ({ params }: { params: { slug: string } }) => {
         <div className="overflow-x-hidden">
           {(appearanceSettings.showTableOfContentsOnMobile === undefined ||
             appearanceSettings.showTableOfContentsOnMobile) && (
-            <Toc
-              jumpToText={await getString('jumpToHeadingText', 'Jump to...')}
-              tableOfContentsText={await getString('tableOfContentsHeadingText', 'Table of Contents')}
-              backToTopText={await getString('backToTopButtonLabel', 'Back to top')}
-            />
+            <div className="lg:hidden">
+              <Toc
+                jumpToText={await getString('jumpToHeadingText', 'Jump to...')}
+                tableOfContentsText={await getString('tableOfContentsHeadingText', 'Table of Contents')}
+                backToTopText={await getString('backToTopButtonLabel', 'Back to top')}
+              />
+            </div>
           )}
           <div className={`eggspress-content eggspress-content-extended`}>
             {frontmatter.isContentHidden ? (

--- a/app/page/[slug]/page.tsx
+++ b/app/page/[slug]/page.tsx
@@ -66,7 +66,7 @@ const PagePage = async ({ params }: { params: { slug: string } }) => {
 
       <div className="flex justify-between w-full">
         <div className="overflow-x-hidden">
-          <div className="mb-12 lg:hidden">
+          <div className="lg:hidden">
             <Toc
               jumpToText={await getString('jumpToHeadingText', 'Jump to...')}
               tableOfContentsText={await getString('tableOfContentsHeadingText', 'Table of Contents')}


### PR DESCRIPTION
**What is this?**
A fix to resolve a bug that causes mobile table of contents (which appears above a post's content) to be visible at all viewport widths, including on desktop. This bug is introduced in the most recent PR due to the removal of a `div` tag wrapping the mobile table of contents element. This PR restores the missing `div` tag.